### PR TITLE
Finally update to 280 character tweets

### DIFF
--- a/clap.js
+++ b/clap.js
@@ -7,7 +7,7 @@
         var out = inEl.value.split(/\s+/).join(` \uD83D\uDC4F${tone} `);
         outEl.innerText = out;
         // Counts by unicode code point, not grapheme, which is how Twitter does it
-        var outLength = 140 - [...out].length;
+        var outLength = 280 - [...out].length;
         count.innerText = outLength;
         if (outLength < 0) {
             count.classList.add('long');

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <textarea id="inel" rows=2 placeholder="text to &#x1f44f;ify..."></textarea>
 	<div id="outgroup">
 		<div id="outel"></div>
-		<div id="count">140</div>
+		<div id="count">280</div>
 	</div>
     <p>skin tone:</p>
     <p>


### PR DESCRIPTION
Quick fix to "support" 280 character tweets. Note that since Twitter introduced 280 character tweets, they treat some codepoints as two characters (notably those used in Chinese, Japanese, and Korean).